### PR TITLE
fix SQL error in scheduled_vs_spent_time

### DIFF
--- a/app/views/my/blocks/_scheduled_vs_spent_time.html.erb
+++ b/app/views/my/blocks/_scheduled_vs_spent_time.html.erb
@@ -25,7 +25,7 @@
 	sql << " GROUP BY project_id, date"
 	sql << ") AS results"
 	sql << " LEFT JOIN #{Project.table_name} AS p ON p.id = results.project_id"
-	sql << " GROUP BY project_id"
+	sql << " GROUP BY p.id, p.name"
 	this_day = ActiveRecord::Base.connection.select_all(sql % [date_on, date_on, date_on, date_on]).index_by { |x| x["id"].to_i }
 	this_week = ActiveRecord::Base.connection.select_all(sql % [week_from, week_to, week_from, week_to]).index_by { |x| x["id"].to_i }
 	this_month = ActiveRecord::Base.connection.select_all(sql % [month_from, month_to, month_from, month_to]).index_by { |x| x["id"].to_i }


### PR DESCRIPTION
ActionView::TemplateError (PGError: ERROR:  column "p.name" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: SELECT p.name, p.id, SUM(hours) AS hours, SUM(logged_hours) ...

I was tired of not seeing 'My page' anymore since I added the block from this plugin, which caused a 500
all the time. So there is a fix :P
