### PR TITLE
Make dependency to holidays gem explicit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gem 'holidays', github: 'alexdunae/holidays'


### PR DESCRIPTION
In addition to reference the gem, I also use the most current lib from github. The latest release version is a bit out of date.
