### PR TITLE
Removed issue.subject - because of double print

### DIFF
--- a/app/views/versions/show.html.erb
+++ b/app/views/versions/show.html.erb
@@ -47,7 +47,7 @@
 <fieldset class="related-issues"><legend><%= l(:label_related_issues) %></legend>
 <ul>
 <% issues.each do |issue| -%>
-    <li><%= link_to_issue(issue) %>: <%=h issue.subject %></li>
+    <li><%= link_to_issue(issue) %></li>
 <% end -%>
 </ul>
 </fieldset>


### PR DESCRIPTION
issue.subject already printed once by link_to_issue()
