### PR TITLE
Fix broken tab links

### DIFF
--- a/app/views/schedules/_calendar.html.erb
+++ b/app/views/schedules/_calendar.html.erb
@@ -2,8 +2,8 @@
     <div class="tabs">
         <% url_params = { :controller => 'schedules', :date => @date } %>
         <ul>
-            <li><%= link_to(l(:label_user_plural), "users", {:class => (@focus == 'users' ? 'selected' : nil)}) %></li>
-            <li><%= link_to(l(:label_project_plural), "projects", {:class => (@focus == 'projects' ? 'selected' : nil)}) %></li>
+            <li><%= link_to(l(:label_user_plural), 'schedules/users', {:class => (@focus == 'users' ? 'selected' : nil)}) %></li>
+            <li><%= link_to(l(:label_project_plural), 'schedules/projects', {:class => (@focus == 'projects' ? 'selected' : nil)}) %></li>
         </ul>
     </div>
 <% end %>


### PR DESCRIPTION
The tab links on the 'All schedules' page has broken links to the Users and Projects pages.
