### PR TITLE
Verbose installation guidelines to avoid 500 internal error and db migration errors

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -13,9 +13,15 @@ Primary developer: Brad Beattie
 
 == Installation
 
-Add this repository to your #{RAILS_ROOT}/plugins/redmine_schedules
+1) Clone the repository
 
-In #{RAILS_ROOT} run the command
+2) Rename <code>redmine-schedules-plugin </code> to <code>redmine_schedules</code>
+
+3) Copy the plugin to <code>#{RAILS_ROOT}/plugins/ </code>
+
+4) In #{RAILS_ROOT} run the command
 
     bundle install
     rake redmine:plugins:migrate
+
+5) Restart redmine


### PR DESCRIPTION
Not renaming the folder actually has unintended effects like 500 Internal Error and db migration errors and the plugin does not work.
