### PR TITLE
Explicitly reference github over HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-gem 'holidays', :github => 'alexdunae/holidays'
+gem 'holidays', :git => 'https://github.com/alexdunae/holidays'


### PR DESCRIPTION
Some proxies and firewalls don't allow outgoing access over the git protocol.
